### PR TITLE
Makefile: add 'make install' trivial target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
 # Licensed under GPL v3 or later
 
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
+INSTALL = install
+
 CFLAGS += -Wall -Wextra -std=c99 -pedantic
 
 SDL1_CFLAGS := $(shell pkg-config SDL_gfx --cflags)
@@ -9,8 +13,12 @@ SDL1_LDFLAGS := $(shell pkg-config SDL_gfx --libs)
 SDL2_CFLAGS := $(shell sdl2-config --cflags)
 SDL2_LDFLAGS := $(shell sdl2-config --libs)
 
+ALL_APPS = \
+	sdl1_video_demo \
+	sdl2_video_demo
+
 .PHONY: all
-all: sdl1_video_demo sdl2_video_demo
+all: $(ALL_APPS)
 
 .PHONY: clean
 clean:
@@ -21,3 +29,8 @@ sdl1_video_demo: sdl1_video_demo.c
 
 sdl2_video_demo: sdl2_video_demo.c
 	$(CC) $< -o $@ $(SDL2_CFLAGS) $(CFLAGS) $(SDL2_LDFLAGS) $(LDFLAGS)
+
+.PHONY: install
+install: $(ALL_APPS)
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 0755 -t $(DESTDIR)$(BINDIR) $(ALL_APPS)


### PR DESCRIPTION
While at it added missing 'sdl' input. In nixpkgs SDL and SDL-gfx get installed into different --prefix= paths. As a result SDL.h does not get located:

    ...SDL_gfx-2.0.26/include/SDL/SDL_rotozoom.h:44:10:
        fatal error: SDL.h: No such file or directory